### PR TITLE
Fix incorrect parsing of large values in VGA scratch register.

### DIFF
--- a/uart-render-controller.c
+++ b/uart-render-controller.c
@@ -139,7 +139,7 @@ static void set_renderer_running(struct render_ctx *ctx, bool running)
 
 static int read_vga_pw_reg(struct render_ctx *ctx, uint8_t *regp)
 {
-	char buf[12]; /* Cover largest 32 bit unsigned int as decimal + \n */
+	char buf[12]; /* Cover 32 bit unsigned int as decimal + \n + \0 */
 	char *endp;
 	unsigned long tmp;
 	int rc;
@@ -150,7 +150,7 @@ static int read_vga_pw_reg(struct render_ctx *ctx, uint8_t *regp)
 		return -1;
 	}
 
-	rc = read(ctx->vga_pw_fd, buf, sizeof(buf));
+	rc = read(ctx->vga_pw_fd, buf, sizeof(buf) - 1);
 	if (rc < 1) {
 		warn("Can't read VGA scratch register");
 		return -1;

--- a/uart-render-controller.c
+++ b/uart-render-controller.c
@@ -139,7 +139,8 @@ static void set_renderer_running(struct render_ctx *ctx, bool running)
 
 static int read_vga_pw_reg(struct render_ctx *ctx, uint8_t *regp)
 {
-	char buf[8], *endp;
+	char buf[11]; /* Cover largest 32 bit unsigned int as decimal */
+	char *endp;
 	unsigned long tmp;
 	int rc;
 

--- a/uart-render-controller.c
+++ b/uart-render-controller.c
@@ -139,7 +139,7 @@ static void set_renderer_running(struct render_ctx *ctx, bool running)
 
 static int read_vga_pw_reg(struct render_ctx *ctx, uint8_t *regp)
 {
-	char buf[11]; /* Cover largest 32 bit unsigned int as decimal */
+	char buf[12]; /* Cover largest 32 bit unsigned int as decimal + \n */
 	char *endp;
 	unsigned long tmp;
 	int rc;
@@ -155,6 +155,7 @@ static int read_vga_pw_reg(struct render_ctx *ctx, uint8_t *regp)
 		warn("Can't read VGA scratch register");
 		return -1;
 	}
+	buf[rc] = '\0';
 
 	errno = 0;
 	tmp = strtoul(buf, &endp, 0);


### PR DESCRIPTION
The largest value in the 32 bit VGA scratch register is 0xffffffff, which is 4294967295 decimal. This requires a parsing buffer for 10 digits + `\0` + `\n`. This change increases the parsing buffer to char[12] and explicitly adds `\0` after the read string.

This fixes issue #1.